### PR TITLE
Force update the state container

### DIFF
--- a/src/flux/connect.jsx
+++ b/src/flux/connect.jsx
@@ -13,6 +13,7 @@ export default function connect(propSelect = () => ({}), actionSelect = {}) {
     componentDidMount() {
       this.unsubscribe = getFlux().subscribe(this.notify)
       this.shouldUpdate = true
+      this.forceUpdate()
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
Since children fire their lifecycle events before parents, `initialize()` is called before the state container is subscribed to the store. A `forceUpdate` fixes this. 

This wasn't noticed previously because normally there are at least two decorated components on a page (one table and one pagination control). The second would fire an `initialize()` call after the first had finished subscribing, which would result in them both updating.

Ideally, we would see if the props have actually changed before doing a `forceUpdate`, [as react-redux does](https://github.com/reactjs/react-redux/blob/master/src/components/connectAdvanced.js#L156). Good candidate for a future optimization. At this point, it's hard to imagine that anything using this container would not need to force update after mounting.