### PR TITLE
If caching is off, reset to initial state on mount

### DIFF
--- a/spec/containers/PaginationWrapper.spec.jsx
+++ b/spec/containers/PaginationWrapper.spec.jsx
@@ -110,8 +110,8 @@ describe('<PaginationWrapper />', () => {
         </PaginationWrapper>
       )
 
-      it('does not execute a reload', () => {
-        expect(props.pageActions.reload).toNotHaveBeenCalled()
+      it('does not execute a reset', () => {
+        expect(props.pageActions.reset).toNotHaveBeenCalled()
       })
     })
   })

--- a/spec/containers/PaginationWrapper.spec.jsx
+++ b/spec/containers/PaginationWrapper.spec.jsx
@@ -11,6 +11,7 @@ const MockComponent = () => false
 function getProps(props = {}) {
   return {
     pageActions: {
+      reset: expect.createSpy(),
       reload: expect.createSpy(),
       initialize: expect.createSpy()
     },
@@ -92,8 +93,8 @@ describe('<PaginationWrapper />', () => {
         </PaginationWrapper>
       )
 
-      it('executes a reload', () => {
-        expect(props.pageActions.reload).toHaveBeenCalled()
+      it('executes a reset', () => {
+        expect(props.pageActions.reset).toHaveBeenCalled()
       })
     })
 

--- a/spec/reducer.spec.js
+++ b/spec/reducer.spec.js
@@ -326,6 +326,50 @@ describe('pagination reducer', () => {
     expect(state.get('results').toJS()).toEqual(results)
   })
 
+  describe('RESET_PAGINATOR', () => {
+    const listId = 'custom'
+    const initialSettings = {
+      pageSize: defaultPaginator.get('pageSize') + 5
+    }
+
+    const customReducer = createPaginator({ listId, initialSettings })
+    const actions = composables({ listId })
+
+    context('when the state has changed', () => {
+      const changedState = defaultPaginator.merge({
+        pageSize: initialSettings.pageSize + 10,
+        page: 13,
+        sort: 'created_at',
+        sortReverse: true
+      })
+
+      context('when called with no arguments', () => {
+        it('resets the list using the initial settings', () => {
+          const finalState = customReducer(changedState, actions.reset())
+          const expectedState = defaultPaginator.merge(initialSettings).merge({
+            initialized: true,
+            stale: true
+          })
+
+          expect(finalState).toEqual(expectedState)
+        })
+      })
+
+      context('when called with overrides', () => {
+        it('resets the list using the initial settings and overrides', () => {
+          const overrides = { pageSize: initialSettings.pageSize + 30 }
+          const finalState = customReducer(changedState, actions.reset(overrides))
+          const expectedState = defaultPaginator.merge(initialSettings).merge({
+            initialized: true,
+            stale: true
+          }).merge(overrides)
+
+          expect(finalState).toEqual(expectedState)
+        })
+      })
+    })
+  })
+
   describe('UPDATE_ITEMS', () => {
     const itemId = 'someId'
     const results = [{ id: itemId, name: 'Pouty Stout' }]

--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -1,4 +1,5 @@
 export const INITIALIZE_PAGINATOR = '@@paginate-this/INITIALIZE_PAGINATOR'
+export const RESET_PAGINATOR = '@@paginate-this/RESET_PAGINATOR'
 export const EXPIRE_PAGINATOR = '@@paginate-this/EXPIRE_PAGINATOR'
 export const EXPIRE_ALL = '@@paginate-this/EXPIRE_ALL'
 export const FOUND_PAGINATOR = '@@paginate-this/FOUND_PAGINATOR'

--- a/src/actions/fetchingComposables.js
+++ b/src/actions/fetchingComposables.js
@@ -37,6 +37,10 @@ export default function fetchingComposables(config) {
       type: resolve(actionTypes.INITIALIZE_PAGINATOR),
       preloaded: config.preloaded
     }),
+    reset: (settings = {}) => ({
+      type: resolve(actionTypes.RESET_PAGINATOR),
+      settings
+    }),
     reload: () => fetcher(id),
     next: () => ({
       type: resolve(actionTypes.NEXT_PAGE)

--- a/src/containers/PaginationWrapper.jsx
+++ b/src/containers/PaginationWrapper.jsx
@@ -45,7 +45,7 @@ export class PaginationWrapper extends Component {
       const { cache } = listInfo(listId)
 
       if (!cache) {
-        pageActions.reload()
+        pageActions.reset()
       } else {
         this.reloadIfStale(this.props)
       }

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -30,6 +30,15 @@ function initialize(state, action) {
   })
 }
 
+function reset(initialSettings) {
+  return (_, action) => defaultPaginator.merge({
+    initialized: true,
+    stale: true,
+    ...initialSettings,
+    ...action.settings
+  })
+}
+
 function expire(state) {
   return state.merge({ stale: true, loadError: null })
 }
@@ -216,6 +225,7 @@ export default function createPaginator(config) {
     ...augmentWith,
     [actionTypes.EXPIRE_ALL]: expire,
     [resolve(actionTypes.INITIALIZE_PAGINATOR)]: initialize,
+    [resolve(actionTypes.RESET_PAGINATOR)]: reset(initialSettings),
     [resolve(actionTypes.EXPIRE_PAGINATOR)]: expire,
     [resolve(actionTypes.PREVIOUS_PAGE)]: prev,
     [resolve(actionTypes.NEXT_PAGE)]: next,

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -33,10 +33,8 @@ function initialize(state, action) {
 function reset(initialSettings) {
   return (_, action) => defaultPaginator.merge({
     initialized: true,
-    stale: true,
-    ...initialSettings,
-    ...action.settings
-  })
+    stale: true
+  }).merge(initialSettings).merge(action.settings || {})
 }
 
 function expire(state) {


### PR DESCRIPTION
Default `paginate-this` behavior is to retain a list's page number and other settings as the user navigates through a SPA. 

With this change, as long as caching is off (which it is by default), returning to the list will cause it to reset to its initial settings.

**Todo**:
- [ ] Specs
